### PR TITLE
Feature/add timestamp extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes this project will be documented in this file. This project a
 
 ### Added
 
-
+- Added support for the [timestamp extension type](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type)
 
 ### Changed
 

--- a/msgpack/_limit.pony
+++ b/msgpack/_limit.pony
@@ -23,3 +23,5 @@ primitive _Limit
   fun positive_fixint(): U8 => 127
   fun negative_fixint_low(): I8 => -32
   fun negative_fixint_high(): I8 => -1
+  fun nsec(): U32 => 999999999
+  fun sec_34(): U64 => 17179869183 // 2^34 - 1

--- a/msgpack/message_pack_decoder.pony
+++ b/msgpack/message_pack_decoder.pony
@@ -297,6 +297,32 @@ primitive MessagePackDecoder
     (b.u8()?, b.block(size)?)
 
   //
+  // timestamp format family
+  //
+
+  fun timestamp(b: Reader): (I64, I64) ? =>
+    let t = _read_type(b)?
+
+    b.i8()?
+    var nsec: I64 = 0
+    var sec: I64 = 0
+    if t == _FormatName.fixext_4() then
+      sec = b.u32_be()?.i64()
+    elseif t == _FormatName.fixext_8() then
+      let u: U64 = b.u64_be()?
+      nsec = (u >> 34).i64()
+      sec = (u - (nsec.u64() << 34)).i64()
+    elseif t == _FormatName.ext_8() then
+      b.u8()?
+      nsec = b.u32_be()?.i64()
+      sec = b.i64_be()?
+    else
+      error
+    end
+
+    (sec, nsec)
+
+  //
   // support functions
   //
 

--- a/msgpack/message_pack_encoder.pony
+++ b/msgpack/message_pack_encoder.pony
@@ -187,7 +187,7 @@ primitive MessagePackEncoder
     Attempting to encode a `ByteSeq` larger than (2^8)-1 bytes will result in
     an `error`.
     """
-    _write_btye_array_8(b, v, _FormatName.str_8())?
+    _write_byte_array_8(b, v, _FormatName.str_8())?
 
   fun str_16(b: Writer, v: ByteSeq) ? =>
     """
@@ -196,7 +196,7 @@ primitive MessagePackEncoder
     Attempting to encode a `ByteSeq` larger than (2^16)-1 bytes will result in
     an `error`.
     """
-    _write_btye_array_16(b, v, _FormatName.str_16())?
+    _write_byte_array_16(b, v, _FormatName.str_16())?
 
    fun str_32(b: Writer, v: ByteSeq) ? =>
     """
@@ -205,7 +205,7 @@ primitive MessagePackEncoder
     Attempting to encode a `ByteSeq` larger than (2^32)-1 bytes will result in
     an `error`.
     """
-    _write_btye_array_32(b, v, _FormatName.str_32())?
+    _write_byte_array_32(b, v, _FormatName.str_32())?
 
   //
   // bin format family
@@ -218,7 +218,7 @@ primitive MessagePackEncoder
     Attempting to encode a `ByteSeq` larger than (2^8)-1 bytes will result in
     an `error`.
     """
-    _write_btye_array_8(b, v, _FormatName.bin_8())?
+    _write_byte_array_8(b, v, _FormatName.bin_8())?
 
   fun bin_16(b: Writer, v: ByteSeq) ? =>
     """
@@ -227,7 +227,7 @@ primitive MessagePackEncoder
     Attempting to encode a `ByteSeq` larger than (2^16)-1 bytes will result in
     an `error`.
     """
-    _write_btye_array_16(b, v, _FormatName.bin_16())?
+    _write_byte_array_16(b, v, _FormatName.bin_16())?
 
    fun bin_32(b: Writer, v: ByteSeq) ? =>
      """
@@ -236,7 +236,7 @@ primitive MessagePackEncoder
      Attempting to encode a `ByteSeq` larger than (2^32)-1 bytes will result in
      an `error`.
      """
-    _write_btye_array_32(b, v, _FormatName.bin_32())?
+    _write_byte_array_32(b, v, _FormatName.bin_32())?
 
   //
   // array format family
@@ -538,7 +538,7 @@ primitive MessagePackEncoder
   fun _write_fixed_value(b: Writer, v: U8) =>
     b.u8(v)
 
-  fun _write_btye_array_8(b: Writer, v: ByteSeq, t: U8) ? =>
+  fun _write_byte_array_8(b: Writer, v: ByteSeq, t: U8) ? =>
     if v.size() <= U8.max_value().usize() then
       _write_type(b, t)
       b.u8(v.size().u8())
@@ -547,7 +547,7 @@ primitive MessagePackEncoder
       error
     end
 
-  fun _write_btye_array_16(b: Writer, v: ByteSeq, t: U8) ? =>
+  fun _write_byte_array_16(b: Writer, v: ByteSeq, t: U8) ? =>
     if v.size() <= U16.max_value().usize() then
       _write_type(b, t)
       b.u16_be(v.size().u16())
@@ -556,7 +556,7 @@ primitive MessagePackEncoder
       error
     end
 
-  fun _write_btye_array_32(b: Writer, v: ByteSeq, t: U8) ? =>
+  fun _write_byte_array_32(b: Writer, v: ByteSeq, t: U8) ? =>
     if v.size() <= U32.max_value().usize() then
       _write_type(b, t)
       b.u32_be(v.size().u32())


### PR DESCRIPTION
Closes #9.

I also took the liberty of fixing some function names with what I believe were typos.

Please note that I was unable to run the full test suite on my laptop, as I ran out of memory pretty quickly. That said, I ran the unit tests that I added, and they all succeeded. I guess we'll see that CircleCI says.

I tried to decode timestamps into `PosixDate` objects, but ran into a lot of difficulty with integer types. From what I understand, PosixDate uses I32 for its fields, but the underlying `struct tm` uses `time_t`, which is specified to be `long int`, which should be 64-bits on 64-bit systems, but only 32-bits on 32-bit systems. Trying to massage the 64-bit seconds value into the `I32` members proved too difficult to me, so now I return something similar to what `Time.now()` gives.

Please let me know if there are any changes you'd like to see!