### PR TITLE
Switch documentation generation to pony-doc

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -9,19 +9,34 @@ permissions:
   id-token: write
   packages: read
 
+concurrency:
+  group: "update-documentation"
+  cancel-in-progress: true
+
 jobs:
   generate-documentation:
     name: Generate documentation for release
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
-      - uses: actions/checkout@v1
-      - name: Generate documentation and upload
-        uses: docker://ghcr.io/ponylang/library-documentation-action:release
-        with:
-          site_url: "https://seantallen-org.github.io/msgpack/"
-          library_name: "msgpack"
-          docs_build_dir: "build/msgpack-docs"
-          git_user_name: "Sean T. Allen"
-          git_user_email: "sean@seantallen.com"
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Generate documentation
+        run: /entrypoint.py
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          INPUT_SITE_URL: "https://seantallen-org.github.io/msgpack/"
+          INPUT_LIBRARY_NAME: "msgpack"
+          INPUT_DOCS_BUILD_DIR: "build/msgpack-docs"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'build/msgpack-docs/site/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,13 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
-permissions:
-  packages: read
-
 concurrency: release
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  packages: read
 
 jobs:
   # validation to assure that we should in fact continue with the release should
@@ -19,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -30,25 +33,35 @@ jobs:
 
   generate-documentation:
     name: Generate documentation for release
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs:
       - pre-artefact-creation
+    container:
+      image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
-      - name: Generate documentation and upload
-        uses: docker://ghcr.io/ponylang/library-documentation-action:release
-        with:
-          site_url: "https://seantallen-org.github.io/msgpack/"
-          library_name: "msgpack"
-          docs_build_dir: "build/msgpack-docs"
-          git_user_name: "Sean T. Allen"
-          git_user_email: "sean@seantallen.com"
+      - name: Generate documentation
+        run: /entrypoint.py
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          INPUT_SITE_URL: "https://seantallen-org.github.io/msgpack/"
+          INPUT_LIBRARY_NAME: "msgpack"
+          INPUT_DOCS_BUILD_DIR: "build/msgpack-docs"
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'build/msgpack-docs/site/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   trigger-release-announcement:
     name: Trigger release announcement
@@ -56,7 +69,7 @@ jobs:
     needs:
       - generate-documentation
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ config ?= release
 
 PACKAGE := msgpack
 COMPILE_WITH := ponyc
+BUILD_DOCS_WITH := corral run -- pony-doc
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR ?= $(PACKAGE)
@@ -43,9 +44,9 @@ clean:
 realclean:
 	rm -rf build
 
-$(docs_dir): $(GEN_FILES) $(SOURCE_FILES)
+$(docs_dir): $(SOURCE_FILES)
 	rm -rf $(docs_dir)
-	${PONYC} --docs-public --pass=docs --output build $(SRC_DIR)
+	$(BUILD_DOCS_WITH) --output build $(SRC_DIR)
 
 docs: $(docs_dir)
 


### PR DESCRIPTION
Mirrors the pattern used across ponylang libraries for documentation generation.

Makefile: adds `BUILD_DOCS_WITH` variable using `corral run -- pony-doc`, replacing `ponyc --docs-public --pass=docs`.

CI workflows (`generate-documentation.yml` and `release.yml`): switches from `library-documentation-action` (v1, Docker action with RELEASE_TOKEN push) to `library-documentation-action-v2` (container with GitHub Pages artifact deployment). Checkout actions updated to v6.0.2. Permissions updated to include `pages: write` and `id-token: write` for Pages deployment.